### PR TITLE
feat: VSPRINT-002 extension entry point and command registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,21 @@
         "command": "vsprint.printSelection",
         "title": "VSPrint: Print Selection"
       }
-    ]
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "vsprint.printFile",
+          "group": "navigation@1",
+          "when": "editorTextFocus"
+        },
+        {
+          "command": "vsprint.printSelection",
+          "group": "navigation@2",
+          "when": "editorHasSelection"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run build:prod",

--- a/src/commands/printFile.ts
+++ b/src/commands/printFile.ts
@@ -1,0 +1,83 @@
+import * as vscode from 'vscode';
+import { logger } from '../utils/logger';
+
+/**
+ * Metadata extracted from the current file
+ */
+export interface FileMetadata {
+  fileName: string;
+  filePath: string;
+  languageId: string;
+  lineCount: number;
+  content: string;
+}
+
+/**
+ * Extract metadata from the active text editor
+ */
+function extractFileMetadata(editor: vscode.TextEditor): FileMetadata {
+  const document = editor.document;
+
+  return {
+    fileName: document.fileName.split(/[\\/]/).pop() || 'Unknown',
+    filePath: document.uri.fsPath,
+    languageId: document.languageId,
+    lineCount: document.lineCount,
+    content: document.getText()
+  };
+}
+
+/**
+ * Command handler for printing the current file
+ * Extracts file metadata and prepares it for printing
+ */
+export async function printFileCommand(): Promise<void> {
+  logger.info('Print File command invoked');
+
+  // Get the active text editor
+  const editor = vscode.window.activeTextEditor;
+
+  // Handle case when no file is open
+  if (!editor) {
+    const errorMessage = 'No active file to print. Please open a file first.';
+    logger.warn(errorMessage);
+    vscode.window.showErrorMessage(errorMessage);
+    return;
+  }
+
+  try {
+    // Extract file metadata
+    const metadata = extractFileMetadata(editor);
+
+    logger.info(`File metadata extracted: ${metadata.fileName} (${metadata.lineCount} lines)`);
+
+    // Show success message with file information
+    const message = `Ready to print: ${metadata.fileName} (${metadata.lineCount} lines)`;
+    vscode.window.showInformationMessage(message);
+
+    logger.info('Print File command completed successfully');
+
+    // TODO: In future tickets, this metadata will be passed to the renderer
+    // For now, we just extract and log the metadata
+    return;
+
+  } catch (error) {
+    const errorMessage = 'Failed to extract file metadata';
+    logger.error(errorMessage, error as Error);
+    vscode.window.showErrorMessage(`${errorMessage}: ${(error as Error).message}`);
+    throw error;
+  }
+}
+
+/**
+ * Register the print file command
+ */
+export function registerPrintFileCommand(context: vscode.ExtensionContext): void {
+  const disposable = vscode.commands.registerCommand(
+    'vsprint.printFile',
+    printFileCommand
+  );
+
+  context.subscriptions.push(disposable);
+  logger.info('Print File command registered');
+}

--- a/src/commands/printSelection.ts
+++ b/src/commands/printSelection.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import { logger } from '../utils/logger';
+
+/**
+ * Command handler for printing the current selection
+ * This is a placeholder implementation for future development
+ */
+export async function printSelectionCommand(): Promise<void> {
+  logger.info('Print Selection command invoked');
+
+  // Get the active text editor
+  const editor = vscode.window.activeTextEditor;
+
+  // Handle case when no file is open
+  if (!editor) {
+    const errorMessage = 'No active file. Please open a file first.';
+    logger.warn(errorMessage);
+    vscode.window.showErrorMessage(errorMessage);
+    return;
+  }
+
+  // Get the current selection
+  const selection = editor.selection;
+  const selectedText = editor.document.getText(selection);
+
+  // Handle case when no text is selected
+  if (!selectedText || selectedText.trim().length === 0) {
+    const errorMessage = 'No text selected. Please select text to print.';
+    logger.warn(errorMessage);
+    vscode.window.showErrorMessage(errorMessage);
+    return;
+  }
+
+  try {
+    // Extract selection metadata
+    const startLine = selection.start.line + 1; // Convert to 1-based
+    const endLine = selection.end.line + 1;
+    const lineCount = endLine - startLine + 1;
+
+    logger.info(`Selection extracted: lines ${startLine}-${endLine} (${lineCount} lines)`);
+
+    // Show placeholder message
+    const message = `Print Selection feature will be implemented in a future update. Selected: ${lineCount} line(s)`;
+    vscode.window.showInformationMessage(message);
+
+    logger.info('Print Selection command completed (placeholder)');
+
+  } catch (error) {
+    const errorMessage = 'Failed to process selection';
+    logger.error(errorMessage, error as Error);
+    vscode.window.showErrorMessage(`${errorMessage}: ${(error as Error).message}`);
+    throw error;
+  }
+}
+
+/**
+ * Register the print selection command
+ */
+export function registerPrintSelectionCommand(context: vscode.ExtensionContext): void {
+  const disposable = vscode.commands.registerCommand(
+    'vsprint.printSelection',
+    printSelectionCommand
+  );
+
+  context.subscriptions.push(disposable);
+  logger.info('Print Selection command registered');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,46 @@
 import * as vscode from 'vscode';
+import { logger } from './utils/logger';
+import { registerPrintFileCommand } from './commands/printFile';
+import { registerPrintSelectionCommand } from './commands/printSelection';
 
-export function activate(_context: vscode.ExtensionContext) {
-  // Extension activation logic will be implemented in subsequent tickets
+/**
+ * Extension activation function
+ * Called when the extension is activated (command invoked, etc.)
+ */
+export function activate(context: vscode.ExtensionContext): void {
+  // Initialize logger
+  logger.initialize('VSPrint');
+  logger.info('VSPrint extension activated');
+
+  try {
+    // Register commands
+    registerPrintFileCommand(context);
+    registerPrintSelectionCommand(context);
+
+    logger.info('All commands registered successfully');
+
+    // Show activation message in output channel
+    const outputChannel = logger.getOutputChannel();
+    if (outputChannel) {
+      context.subscriptions.push(outputChannel);
+    }
+
+    logger.info('VSPrint extension initialization complete');
+
+  } catch (error) {
+    logger.error('Failed to activate VSPrint extension', error as Error);
+    vscode.window.showErrorMessage(
+      `Failed to activate VSPrint: ${(error as Error).message}`
+    );
+    throw error;
+  }
 }
 
-export function deactivate() {
-  // Cleanup logic will be implemented as needed
+/**
+ * Extension deactivation function
+ * Called when the extension is deactivated
+ */
+export function deactivate(): void {
+  logger.info('VSPrint extension deactivated');
+  logger.dispose();
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode';
+
+/**
+ * Logger utility for VSPrint extension
+ * Provides centralized logging to VS Code output channel
+ */
+class Logger {
+  private outputChannel: vscode.OutputChannel | undefined;
+
+  /**
+   * Initialize the logger with an output channel
+   */
+  public initialize(channelName: string): void {
+    this.outputChannel = vscode.window.createOutputChannel(channelName);
+  }
+
+  /**
+   * Log an info message
+   */
+  public info(message: string): void {
+    this.log('INFO', message);
+  }
+
+  /**
+   * Log a warning message
+   */
+  public warn(message: string): void {
+    this.log('WARN', message);
+  }
+
+  /**
+   * Log an error message
+   */
+  public error(message: string, error?: Error): void {
+    const errorMessage = error ? `${message}: ${error.message}` : message;
+    this.log('ERROR', errorMessage);
+    if (error?.stack) {
+      this.log('ERROR', error.stack);
+    }
+  }
+
+  /**
+   * Internal logging method
+   */
+  private log(level: string, message: string): void {
+    if (!this.outputChannel) {
+      console.warn('Logger not initialized');
+      return;
+    }
+    const timestamp = new Date().toISOString();
+    this.outputChannel.appendLine(`[${timestamp}] [${level}] ${message}`);
+  }
+
+  /**
+   * Get the output channel instance
+   */
+  public getOutputChannel(): vscode.OutputChannel | undefined {
+    return this.outputChannel;
+  }
+
+  /**
+   * Dispose the output channel
+   */
+  public dispose(): void {
+    this.outputChannel?.dispose();
+  }
+}
+
+// Export singleton instance
+export const logger = new Logger();


### PR DESCRIPTION
## Summary
- Implement full extension entry point with activate/deactivate
- Create printFile and printSelection command handlers
- Add logger utility for debugging
- Register commands in Command Palette and context menu

## Changes
- `src/extension.ts` - Full activation with command registration
- `src/commands/printFile.ts` - File metadata extraction
- `src/commands/printSelection.ts` - Selection handler (placeholder)
- `src/utils/logger.ts` - Output channel logging
- `package.json` - Context menu contributions

## Test plan
- [x] Extension activates without errors
- [x] Commands appear in Command Palette
- [x] Print File extracts metadata correctly
- [x] Handles no active file gracefully

Closes #2