### PR TITLE
feat: VSPRINT-004 system printer integration via browser

### DIFF
--- a/src/commands/printFile.ts
+++ b/src/commands/printFile.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { logger } from '../utils/logger';
 import { generatePrintHtml } from '../renderers/htmlRenderer';
 import { getSettings } from '../config/settings';
+import { printHtml } from '../renderers/printerRenderer';
 
 /**
  * Metadata extracted from the current file
@@ -61,18 +62,13 @@ export async function printFileCommand(): Promise<void> {
     const html = generatePrintHtml(metadata.content, metadata, settings);
     logger.info(`HTML generated successfully (${html.length} bytes)`);
 
-    // Show success message with file information
-    const message = `Ready to print: ${metadata.fileName} (${metadata.lineCount} lines)`;
-    vscode.window.showInformationMessage(message);
+    // Print via browser
+    await printHtml(html, metadata.fileName);
 
     logger.info('Print File command completed successfully');
 
-    // TODO: In future tickets, the HTML will be displayed in a webview for printing
-    // For now, we generate the HTML and log success
-    return;
-
   } catch (error) {
-    const errorMessage = 'Failed to generate print HTML';
+    const errorMessage = 'Failed to print file';
     logger.error(errorMessage, error as Error);
     vscode.window.showErrorMessage(`${errorMessage}: ${(error as Error).message}`);
     throw error;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import { logger } from './utils/logger';
 import { registerPrintFileCommand } from './commands/printFile';
 import { registerPrintSelectionCommand } from './commands/printSelection';
+import { getTempFiles, clearTempFileTracker } from './renderers/printerRenderer';
+import { cleanupTempFiles } from './utils/tempFile';
 
 /**
  * Extension activation function
@@ -40,7 +42,17 @@ export function activate(context: vscode.ExtensionContext): void {
  * Extension deactivation function
  * Called when the extension is deactivated
  */
-export function deactivate(): void {
+export async function deactivate(): Promise<void> {
+  logger.info('VSPrint extension deactivating');
+
+  // Clean up temporary files
+  const tempFiles = getTempFiles();
+  if (tempFiles.length > 0) {
+    logger.info(`Cleaning up ${tempFiles.length} temporary file(s)`);
+    await cleanupTempFiles(tempFiles);
+    clearTempFileTracker();
+  }
+
   logger.info('VSPrint extension deactivated');
   logger.dispose();
 }

--- a/src/renderers/printerRenderer.ts
+++ b/src/renderers/printerRenderer.ts
@@ -1,0 +1,101 @@
+import * as vscode from 'vscode';
+import { logger } from '../utils/logger';
+import { getTempFilePath, writeTempFile } from '../utils/tempFile';
+
+/**
+ * Singleton class to manage temp files created for printing
+ */
+class TempFileTracker {
+  private static instance: TempFileTracker;
+  private tempFiles: string[] = [];
+
+  private constructor() {}
+
+  static getInstance(): TempFileTracker {
+    if (!TempFileTracker.instance) {
+      TempFileTracker.instance = new TempFileTracker();
+    }
+    return TempFileTracker.instance;
+  }
+
+  addFile(filePath: string): void {
+    this.tempFiles.push(filePath);
+  }
+
+  getFiles(): string[] {
+    return [...this.tempFiles];
+  }
+
+  clear(): void {
+    this.tempFiles = [];
+  }
+}
+
+/**
+ * Get the platform-specific keyboard shortcut for printing
+ */
+function getPrintShortcut(): string {
+  const platform = process.platform;
+  return platform === 'darwin' ? 'Cmd+P' : 'Ctrl+P';
+}
+
+/**
+ * Print HTML content by opening it in the default browser
+ * The browser's print dialog handles the actual printing
+ *
+ * @param html - HTML content to print
+ * @param fileName - Name of the file being printed (for user message)
+ * @throws Error if browser fails to open
+ */
+export async function printHtml(html: string, fileName: string): Promise<void> {
+  try {
+    // Generate temp file path
+    const tempFilePath = getTempFilePath('vsprint', '.html');
+    logger.info(`Preparing to print via browser: ${tempFilePath}`);
+
+    // Write HTML to temp file
+    await writeTempFile(html, tempFilePath);
+
+    // Track temp file for cleanup
+    TempFileTracker.getInstance().addFile(tempFilePath);
+
+    // Convert to file URI
+    const fileUri = vscode.Uri.file(tempFilePath);
+
+    // Open in default browser
+    const opened = await vscode.env.openExternal(fileUri);
+
+    if (!opened) {
+      throw new Error('Failed to open browser');
+    }
+
+    // Show success message with print instructions
+    const shortcut = getPrintShortcut();
+    const message = `Print ready! Use ${shortcut} in your browser to print ${fileName}`;
+    vscode.window.showInformationMessage(message);
+
+    logger.info(`Browser opened successfully for printing: ${fileName}`);
+
+  } catch (error) {
+    logger.error('Failed to print via browser', error as Error);
+    const errorMessage = `Failed to print: ${(error as Error).message}`;
+    vscode.window.showErrorMessage(errorMessage);
+    throw error;
+  }
+}
+
+/**
+ * Get all temp files created during this session
+ *
+ * @returns Array of temp file paths
+ */
+export function getTempFiles(): string[] {
+  return TempFileTracker.getInstance().getFiles();
+}
+
+/**
+ * Clear the temp file tracker (useful for cleanup after deletion)
+ */
+export function clearTempFileTracker(): void {
+  TempFileTracker.getInstance().clear();
+}

--- a/src/utils/tempFile.ts
+++ b/src/utils/tempFile.ts
@@ -1,0 +1,65 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { logger } from './logger';
+
+/**
+ * Generate a temp file path with timestamp prefix
+ *
+ * @param prefix - File name prefix
+ * @param extension - File extension (including dot)
+ * @returns Full path to temp file
+ */
+export function getTempFilePath(prefix: string, extension: string): string {
+  const timestamp = Date.now();
+  const filename = `${prefix}-${timestamp}${extension}`;
+  return path.join(os.tmpdir(), filename);
+}
+
+/**
+ * Write content to a temporary file
+ *
+ * @param content - Content to write
+ * @param filename - Full path to temp file
+ * @returns Path to created file
+ */
+export async function writeTempFile(content: string, filename: string): Promise<string> {
+  try {
+    await fs.writeFile(filename, content, 'utf8');
+    logger.info(`Temporary file created: ${filename}`);
+    return filename;
+  } catch (error) {
+    logger.error('Failed to write temporary file', error as Error);
+    throw new Error(`Failed to write temporary file: ${(error as Error).message}`);
+  }
+}
+
+/**
+ * Clean up temporary files
+ *
+ * @param files - Array of file paths to delete
+ */
+export async function cleanupTempFiles(files: string[]): Promise<void> {
+  if (files.length === 0) {
+    return;
+  }
+
+  logger.info(`Cleaning up ${files.length} temporary file(s)`);
+
+  const results = await Promise.allSettled(
+    files.map(async (file) => {
+      try {
+        await fs.unlink(file);
+        logger.info(`Deleted temporary file: ${file}`);
+      } catch (error) {
+        // File may already be deleted or not exist, log but don't throw
+        logger.warn(`Failed to delete temporary file: ${file} - ${(error as Error).message}`);
+      }
+    })
+  );
+
+  const failed = results.filter(r => r.status === 'rejected').length;
+  if (failed > 0) {
+    logger.warn(`Failed to delete ${failed} temporary file(s)`);
+  }
+}


### PR DESCRIPTION
## Summary
- Implement browser-based printing via vscode.env.openExternal()
- Add temp file management with cleanup on deactivate
- Cross-platform support (Windows/macOS/Linux)
- Platform-specific print shortcut instructions

## Changes
- `src/renderers/printerRenderer.ts` - Print via browser
- `src/utils/tempFile.ts` - Temp file utilities
- `src/commands/printFile.ts` - Complete print flow
- `src/extension.ts` - Cleanup on deactivate

## Test plan
- [x] TypeScript compilation passes
- [x] Browser opens with HTML file
- [x] Print shortcut message shows correctly
- [x] Temp files created in OS temp directory

Closes #4