### PR TITLE
feat: VSPRINT-006 Line wrapping and whitespace visualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,18 @@
           "enum": ["light", "dark", "github-light", "github-dark", "monokai"],
           "default": "github-light",
           "description": "Syntax highlighting theme for printed code"
+        },
+        "vsprint.lineWrap": {
+          "type": "string",
+          "enum": ["none", "soft", "hard"],
+          "default": "soft",
+          "description": "Line wrapping mode: none (overflow), soft (word boundaries), hard (character boundaries)"
+        },
+        "vsprint.showWhitespace": {
+          "type": "string",
+          "enum": ["none", "boundary", "all"],
+          "default": "none",
+          "description": "Whitespace visualization: none (invisible), boundary (between words), all (every space/tab)"
         }
       }
     }

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -8,6 +8,8 @@ export interface PrintSettings {
   fontFamily: string;
   showLineNumbers: boolean;
   theme: string;
+  lineWrap: 'none' | 'soft' | 'hard';
+  showWhitespace: 'none' | 'boundary' | 'all';
 }
 
 /**
@@ -17,7 +19,9 @@ const DEFAULT_SETTINGS: PrintSettings = {
   fontSize: 10,
   fontFamily: "Consolas, Monaco, 'Courier New', monospace",
   showLineNumbers: true,
-  theme: 'github-light'
+  theme: 'github-light',
+  lineWrap: 'soft',
+  showWhitespace: 'none'
 };
 
 /**
@@ -33,6 +37,8 @@ export function getSettings(): PrintSettings {
     fontSize: config.get<number>('fontSize', DEFAULT_SETTINGS.fontSize),
     fontFamily: config.get<string>('fontFamily', DEFAULT_SETTINGS.fontFamily),
     showLineNumbers: config.get<boolean>('showLineNumbers', DEFAULT_SETTINGS.showLineNumbers),
-    theme: config.get<string>('theme', DEFAULT_SETTINGS.theme)
+    theme: config.get<string>('theme', DEFAULT_SETTINGS.theme),
+    lineWrap: config.get<'none' | 'soft' | 'hard'>('lineWrap', DEFAULT_SETTINGS.lineWrap),
+    showWhitespace: config.get<'none' | 'boundary' | 'all'>('showWhitespace', DEFAULT_SETTINGS.showWhitespace)
   };
 }

--- a/src/renderers/htmlRenderer.ts
+++ b/src/renderers/htmlRenderer.ts
@@ -1,6 +1,7 @@
 import { FileMetadata } from '../commands/printFile';
 import { PrintSettings } from '../config/settings';
 import { syntaxHighlighter } from '../services/syntaxHighlighter';
+import { visualizeWhitespace } from '../utils/textTransform';
 
 /**
  * Escape HTML entities to prevent XSS and rendering issues
@@ -18,6 +19,25 @@ function escapeHtml(text: string): string {
   };
 
   return text.replace(/[&<>"']/g, (char) => entityMap[char]);
+}
+
+/**
+ * Get CSS white-space styles based on line wrap mode
+ *
+ * @param lineWrap - Line wrap mode: 'none' | 'soft' | 'hard'
+ * @returns CSS white-space and word-wrap properties
+ */
+function getWhiteSpaceStyles(lineWrap: 'none' | 'soft' | 'hard'): string {
+  switch (lineWrap) {
+    case 'none':
+      return 'white-space: pre; overflow-x: auto;';
+    case 'soft':
+      return 'white-space: pre-wrap; word-wrap: break-word;';
+    case 'hard':
+      return 'white-space: pre-wrap; word-break: break-all;';
+    default:
+      return 'white-space: pre-wrap; word-wrap: break-word;';
+  }
 }
 
 /**
@@ -84,10 +104,14 @@ function generateStyles(settings: PrintSettings, backgroundColor: string, foregr
       .code-line pre {
         margin: 0;
         padding: 0;
-        white-space: pre-wrap;
-        word-wrap: break-word;
+        ${getWhiteSpaceStyles(settings.lineWrap)}
         font-family: inherit;
         font-size: inherit;
+      }
+
+      .ws-space, .ws-tab {
+        color: #ccc;
+        font-weight: normal;
       }
 
       .footer {
@@ -161,7 +185,13 @@ function generateFooter(): string {
  * @returns HTML string for code table
  */
 function generateCodeTable(content: string, settings: PrintSettings, isPreHighlighted: boolean = false): string {
-  const lines = content.split('\n');
+  // Apply whitespace visualization if enabled and content is pre-highlighted
+  let processedContent = content;
+  if (isPreHighlighted && settings.showWhitespace !== 'none') {
+    processedContent = visualizeWhitespace(content, settings.showWhitespace);
+  }
+
+  const lines = processedContent.split('\n');
   let html = '<table class="code-container">\n';
 
   lines.forEach((line, index) => {

--- a/src/utils/textTransform.ts
+++ b/src/utils/textTransform.ts
@@ -1,0 +1,85 @@
+/**
+ * Utilities for transforming and visualizing text content
+ */
+
+/**
+ * Visualize whitespace characters in HTML content
+ *
+ * This function adds visual markers for spaces and tabs while preserving
+ * existing HTML tags from syntax highlighting (e.g., Shiki <span> tags).
+ *
+ * @param html - HTML content (may contain Shiki <span> tags)
+ * @param mode - Visualization mode: 'none' | 'boundary' | 'all'
+ * @returns HTML with whitespace markers
+ */
+export function visualizeWhitespace(html: string, mode: 'none' | 'boundary' | 'all'): string {
+  if (mode === 'none') {
+    return html;
+  }
+
+  // Split content into HTML tags and text segments
+  // This regex matches HTML tags: <...> including attributes
+  const segments: Array<{ isTag: boolean; content: string }> = [];
+  const tagRegex = /<[^>]+>/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagRegex.exec(html)) !== null) {
+    // Add text before tag
+    if (match.index > lastIndex) {
+      segments.push({
+        isTag: false,
+        content: html.substring(lastIndex, match.index)
+      });
+    }
+    // Add tag
+    segments.push({
+      isTag: true,
+      content: match[0]
+    });
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text after last tag
+  if (lastIndex < html.length) {
+    segments.push({
+      isTag: false,
+      content: html.substring(lastIndex)
+    });
+  }
+
+  // Process each segment
+  const result = segments.map(segment => {
+    if (segment.isTag) {
+      // Don't modify HTML tags
+      return segment.content;
+    }
+
+    // Transform text content based on mode
+    let text = segment.content;
+
+    if (mode === 'all') {
+      // Replace all spaces and tabs
+      text = text.replace(/\t/g, '<span class="ws-tab">→</span>');
+      text = text.replace(/ /g, '<span class="ws-space">·</span>');
+    } else if (mode === 'boundary') {
+      // Replace spaces between words (spaces followed by non-space)
+      // Use a more sophisticated approach: mark spaces that are between visible characters
+
+      // First, replace tabs (always visible in boundary mode)
+      text = text.replace(/\t/g, '<span class="ws-tab">→</span>');
+
+      // For boundary mode, mark spaces that separate words
+      // Look for pattern: non-space + spaces + non-space
+      // This regex matches one or more spaces that are followed by a non-space character
+      text = text.replace(/ +(?=\S)/g, (match) => {
+        // Replace each space in the match
+        return match.split('').map(() => '<span class="ws-space">·</span>').join('');
+      });
+    }
+
+    return text;
+  }).join('');
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Add configurable line wrapping: none (overflow), soft (word boundaries), hard (character boundaries)
- Add whitespace visualization: none, boundary (between words), all (every space/tab)
- Create textTransform utility preserving Shiki syntax highlighting
- Space markers (·) and tab markers (→) in subtle gray

## Changes
- `package.json`: Added lineWrap and showWhitespace settings
- `src/config/settings.ts`: Extended PrintSettings interface
- `src/utils/textTransform.ts`: New whitespace visualization utility
- `src/renderers/htmlRenderer.ts`: Dynamic CSS and integration

## Test plan
- [ ] Print file with long lines, lineWrap: "soft" → wraps at words
- [ ] Print file with tabs, showWhitespace: "all" → arrows visible
- [ ] Verify syntax highlighting preserved after whitespace marking

Closes #10