### PR TITLE
feat: VSPRINT-007 Code intelligence (folds and symbols)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,17 @@
           "enum": ["light", "dark", "github-light", "github-dark", "monokai"],
           "default": "github-light",
           "description": "Syntax highlighting theme for printed code"
+        },
+        "vsprint.foldedRegions": {
+          "type": "string",
+          "enum": ["expand", "collapse", "asIs"],
+          "default": "expand",
+          "description": "How to handle folded regions: expand (show all), collapse (show placeholder), asIs (respect editor state)"
+        },
+        "vsprint.showSeparators": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show visual separators between functions and classes"
         }
       }
     }

--- a/src/commands/printFile.ts
+++ b/src/commands/printFile.ts
@@ -3,6 +3,7 @@ import { logger } from '../utils/logger';
 import { generatePrintHtml } from '../renderers/htmlRenderer';
 import { getSettings } from '../config/settings';
 import { printHtml } from '../renderers/printerRenderer';
+import { codeIntelligence } from '../services/codeIntelligence';
 
 /**
  * Metadata extracted from the current file
@@ -13,6 +14,7 @@ export interface FileMetadata {
   languageId: string;
   lineCount: number;
   content: string;
+  uri: vscode.Uri;
 }
 
 /**
@@ -26,7 +28,8 @@ function extractFileMetadata(editor: vscode.TextEditor): FileMetadata {
     filePath: document.uri.fsPath,
     languageId: document.languageId,
     lineCount: document.lineCount,
-    content: document.getText()
+    content: document.getText(),
+    uri: document.uri
   };
 }
 
@@ -58,8 +61,16 @@ export async function printFileCommand(): Promise<void> {
     const settings = getSettings();
     logger.info(`Settings loaded: fontSize=${settings.fontSize}, showLineNumbers=${settings.showLineNumbers}`);
 
+    // Query code intelligence
+    const foldedRanges = settings.foldedRegions !== 'expand'
+      ? await codeIntelligence.getFoldedRanges(metadata.uri, settings.foldedRegions)
+      : [];
+    const symbolBoundaries = settings.showSeparators
+      ? await codeIntelligence.getSymbolBoundaries(metadata.uri)
+      : [];
+
     // Generate HTML
-    const html = await generatePrintHtml(metadata.content, metadata, settings);
+    const html = await generatePrintHtml(metadata.content, metadata, settings, symbolBoundaries, foldedRanges);
     logger.info(`HTML generated successfully (${html.length} bytes)`);
 
     // Print via browser

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -8,6 +8,8 @@ export interface PrintSettings {
   fontFamily: string;
   showLineNumbers: boolean;
   theme: string;
+  foldedRegions: 'expand' | 'collapse' | 'asIs';
+  showSeparators: boolean;
 }
 
 /**
@@ -17,7 +19,9 @@ const DEFAULT_SETTINGS: PrintSettings = {
   fontSize: 10,
   fontFamily: "Consolas, Monaco, 'Courier New', monospace",
   showLineNumbers: true,
-  theme: 'github-light'
+  theme: 'github-light',
+  foldedRegions: 'expand',
+  showSeparators: false
 };
 
 /**
@@ -33,6 +37,8 @@ export function getSettings(): PrintSettings {
     fontSize: config.get<number>('fontSize', DEFAULT_SETTINGS.fontSize),
     fontFamily: config.get<string>('fontFamily', DEFAULT_SETTINGS.fontFamily),
     showLineNumbers: config.get<boolean>('showLineNumbers', DEFAULT_SETTINGS.showLineNumbers),
-    theme: config.get<string>('theme', DEFAULT_SETTINGS.theme)
+    theme: config.get<string>('theme', DEFAULT_SETTINGS.theme),
+    foldedRegions: config.get<'expand' | 'collapse' | 'asIs'>('foldedRegions', DEFAULT_SETTINGS.foldedRegions),
+    showSeparators: config.get<boolean>('showSeparators', DEFAULT_SETTINGS.showSeparators)
   };
 }

--- a/src/renderers/htmlRenderer.ts
+++ b/src/renderers/htmlRenderer.ts
@@ -1,6 +1,7 @@
 import { FileMetadata } from '../commands/printFile';
 import { PrintSettings } from '../config/settings';
 import { syntaxHighlighter } from '../services/syntaxHighlighter';
+import { FoldRange } from '../services/codeIntelligence';
 
 /**
  * Escape HTML entities to prevent XSS and rendering issues
@@ -99,6 +100,17 @@ function generateStyles(settings: PrintSettings, backgroundColor: string, foregr
         color: #666;
       }
 
+      .separator td {
+        border-top: 2px solid #e0e0e0;
+        padding-top: 8px;
+      }
+
+      .fold-placeholder {
+        color: #999;
+        font-style: italic;
+        background-color: #f5f5f5;
+      }
+
       @media print {
         @page {
           margin: 1in;
@@ -158,14 +170,31 @@ function generateFooter(): string {
  * @param content - Code content to render
  * @param settings - Print settings
  * @param isPreHighlighted - Whether content is already HTML (syntax highlighted)
+ * @param symbolBoundaries - Line numbers where separators should be inserted
  * @returns HTML string for code table
  */
-function generateCodeTable(content: string, settings: PrintSettings, isPreHighlighted: boolean = false): string {
+function generateCodeTable(
+  content: string,
+  settings: PrintSettings,
+  isPreHighlighted: boolean = false,
+  symbolBoundaries: number[] = []
+): string {
   const lines = content.split('\n');
+  const boundarySet = new Set(symbolBoundaries);
   let html = '<table class="code-container">\n';
 
   lines.forEach((line, index) => {
     const lineNumber = index + 1;
+
+    // Insert separator row before this line if it's a symbol boundary
+    if (boundarySet.has(lineNumber)) {
+      if (settings.showLineNumbers) {
+        html += `  <tr class="separator"><td colspan="2"></td></tr>\n`;
+      } else {
+        html += `  <tr class="separator"><td></td></tr>\n`;
+      }
+    }
+
     // Only escape if not pre-highlighted
     const lineContent = isPreHighlighted ? line : escapeHtml(line);
 
@@ -186,28 +215,80 @@ function generateCodeTable(content: string, settings: PrintSettings, isPreHighli
 }
 
 /**
+ * Apply fold placeholders to content
+ * Replaces folded regions with a single-line placeholder
+ *
+ * @param content - Code content to process
+ * @param foldedRanges - Array of fold ranges to apply
+ * @returns Content with fold placeholders applied
+ */
+function applyFoldPlaceholders(content: string, foldedRanges: FoldRange[]): string {
+  if (foldedRanges.length === 0) return content;
+
+  const lines = content.split('\n');
+  const linesToRemove = new Set<number>();
+
+  // Mark lines to remove (0-based indexing)
+  for (const range of foldedRanges) {
+    // Remove lines from start+1 to end (inclusive)
+    for (let i = range.start + 1; i <= range.end; i++) {
+      linesToRemove.add(i);
+    }
+  }
+
+  // Build new content with placeholders
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    if (!linesToRemove.has(i)) {
+      result.push(lines[i]);
+      i++;
+    } else {
+      // Find the extent of consecutive removed lines (part of same fold)
+      let start = i;
+      while (i < lines.length && linesToRemove.has(i)) {
+        i++;
+      }
+      const count = i - start;
+      // Insert placeholder with count
+      result.push(`<span class="fold-placeholder">/* ... ${count} lines collapsed ... */</span>`);
+    }
+  }
+
+  return result.join('\n');
+}
+
+/**
  * Generate complete print-ready HTML document
  *
  * @param content - Code content to render
  * @param metadata - File metadata
  * @param settings - Print settings from user configuration
+ * @param symbolBoundaries - Line numbers where separators should be inserted
+ * @param foldedRanges - Folding ranges to apply
  * @returns Complete HTML document string
  */
 export async function generatePrintHtml(
   content: string,
   metadata: FileMetadata,
-  settings: PrintSettings
+  settings: PrintSettings,
+  symbolBoundaries: number[] = [],
+  foldedRanges: FoldRange[] = []
 ): Promise<string> {
   // Get theme colors
   const backgroundColor = await syntaxHighlighter.getThemeBackground(settings.theme);
   const foregroundColor = await syntaxHighlighter.getThemeForeground(settings.theme);
 
+  // Apply fold placeholders before syntax highlighting
+  const processedContent = applyFoldPlaceholders(content, foldedRanges);
+
   // Apply syntax highlighting
-  const highlightedCode = await syntaxHighlighter.highlight(content, metadata.languageId, settings.theme);
+  const highlightedCode = await syntaxHighlighter.highlight(processedContent, metadata.languageId, settings.theme);
 
   const styles = generateStyles(settings, backgroundColor, foregroundColor);
   const header = generateHeader(metadata);
-  const codeTable = generateCodeTable(highlightedCode, settings, true);
+  const codeTable = generateCodeTable(highlightedCode, settings, true, symbolBoundaries);
   const footer = generateFooter();
 
   return `<!DOCTYPE html>

--- a/src/services/codeIntelligence.ts
+++ b/src/services/codeIntelligence.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+
+export interface FoldRange {
+  start: number;
+  end: number;
+  kind?: string;
+}
+
+class CodeIntelligenceService {
+  private static instance: CodeIntelligenceService;
+
+  public static getInstance(): CodeIntelligenceService {
+    if (!CodeIntelligenceService.instance) {
+      CodeIntelligenceService.instance = new CodeIntelligenceService();
+    }
+    return CodeIntelligenceService.instance;
+  }
+
+  /**
+   * Get folding ranges for a document
+   * @param uri - Document URI
+   * @param mode - 'expand' | 'collapse' | 'asIs'
+   */
+  async getFoldedRanges(uri: vscode.Uri, mode: string): Promise<FoldRange[]> {
+    if (mode === 'expand') return [];
+
+    try {
+      const ranges = await vscode.commands.executeCommand<vscode.FoldingRange[]>(
+        'vscode.executeFoldingRangeProvider',
+        uri
+      );
+
+      if (!ranges) return [];
+
+      return ranges.map(r => ({
+        start: r.start,
+        end: r.end,
+        kind: r.kind?.toString()
+      }));
+    } catch {
+      return []; // No folding provider available
+    }
+  }
+
+  /**
+   * Get line numbers where symbol boundaries occur (for separators)
+   * @param uri - Document URI
+   */
+  async getSymbolBoundaries(uri: vscode.Uri): Promise<number[]> {
+    try {
+      const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        'vscode.executeDocumentSymbolProvider',
+        uri
+      );
+
+      if (!symbols || symbols.length === 0) return [];
+
+      // Filter for top-level functions, classes, interfaces, methods
+      const relevantKinds = [
+        vscode.SymbolKind.Function,
+        vscode.SymbolKind.Class,
+        vscode.SymbolKind.Interface,
+        vscode.SymbolKind.Method,
+        vscode.SymbolKind.Enum
+      ];
+
+      const topLevel = symbols.filter(s => relevantKinds.includes(s.kind));
+
+      // Return start line numbers, sorted, skipping the first one (no separator before first symbol)
+      const lineNumbers = topLevel
+        .map(s => s.range.start.line + 1) // +1 for 1-based line numbers
+        .sort((a, b) => a - b);
+
+      // Skip first symbol (don't put separator before first function)
+      return lineNumbers.slice(1);
+    } catch {
+      return []; // No symbol provider available
+    }
+  }
+}
+
+export const codeIntelligence = CodeIntelligenceService.getInstance();


### PR DESCRIPTION
## Summary
- Add fold-aware printing: expand (show all), collapse (placeholder), asIs
- Add symbol boundary separators between functions/classes
- Create codeIntelligence service using VS Code LSP APIs
- Graceful fallback when no LSP provider available

## Changes
- `package.json`: Added foldedRegions and showSeparators settings
- `src/config/settings.ts`: Extended PrintSettings interface
- `src/services/codeIntelligence.ts`: New LSP query service
- `src/commands/printFile.ts`: Added URI and intelligence queries
- `src/renderers/htmlRenderer.ts`: Separator CSS and fold placeholders

## Test plan
- [ ] Print TypeScript with foldedRegions: "collapse" → placeholder shown
- [ ] Print JavaScript with showSeparators: true → separators between functions
- [ ] Print plain text file → no errors (graceful fallback)

Closes #11