### PR TITLE
feat: VSPRINT-008 Import section grouping

### DIFF
--- a/src/commands/printFile.ts
+++ b/src/commands/printFile.ts
@@ -65,9 +65,19 @@ export async function printFileCommand(): Promise<void> {
     const foldedRanges = settings.foldedRegions !== 'expand'
       ? await codeIntelligence.getFoldedRanges(metadata.uri, settings.foldedRegions)
       : [];
-    const symbolBoundaries = settings.showSeparators
+
+    // Get symbol boundaries for function/class separators
+    let symbolBoundaries = settings.showSeparators
       ? await codeIntelligence.getSymbolBoundaries(metadata.uri)
       : [];
+
+    // Get import section separator (always add if imports exist)
+    const importSectionEnd = codeIntelligence.getImportSectionEnd(metadata.content, metadata.languageId);
+    if (importSectionEnd > 0) {
+      // Merge import separator with symbol boundaries, avoiding duplicates
+      const allBoundaries = new Set([importSectionEnd, ...symbolBoundaries]);
+      symbolBoundaries = Array.from(allBoundaries).sort((a, b) => a - b);
+    }
 
     // Generate HTML
     const html = await generatePrintHtml(metadata.content, metadata, settings, symbolBoundaries, foldedRanges);

--- a/src/services/codeIntelligence.ts
+++ b/src/services/codeIntelligence.ts
@@ -6,6 +6,59 @@ export interface FoldRange {
   kind?: string;
 }
 
+/**
+ * Import/require patterns by language
+ * Each pattern matches the start of an import line
+ */
+const IMPORT_PATTERNS: Record<string, RegExp[]> = {
+  // JavaScript/TypeScript: import ... from, require(), export ... from
+  typescript: [
+    /^\s*import\s+/,
+    /^\s*export\s+.*\s+from\s+/,
+    /^\s*(?:const|let|var)\s+.*=\s*require\s*\(/
+  ],
+  javascript: [
+    /^\s*import\s+/,
+    /^\s*export\s+.*\s+from\s+/,
+    /^\s*(?:const|let|var)\s+.*=\s*require\s*\(/
+  ],
+  typescriptreact: [
+    /^\s*import\s+/,
+    /^\s*export\s+.*\s+from\s+/,
+    /^\s*(?:const|let|var)\s+.*=\s*require\s*\(/
+  ],
+  javascriptreact: [
+    /^\s*import\s+/,
+    /^\s*export\s+.*\s+from\s+/,
+    /^\s*(?:const|let|var)\s+.*=\s*require\s*\(/
+  ],
+  // Python: import ..., from ... import
+  python: [
+    /^\s*import\s+/,
+    /^\s*from\s+\S+\s+import\s+/
+  ],
+  // Java: import ...;
+  java: [
+    /^\s*import\s+/
+  ],
+  // Go: import "..." or import (...)
+  go: [
+    /^\s*import\s+[\("]/,
+    /^\s*import\s*$/  // Start of import block
+  ],
+  // Rust: use ...;
+  rust: [
+    /^\s*use\s+/
+  ],
+  // C/C++: #include ...
+  c: [
+    /^\s*#\s*include\s+/
+  ],
+  cpp: [
+    /^\s*#\s*include\s+/
+  ]
+};
+
 class CodeIntelligenceService {
   private static instance: CodeIntelligenceService;
 
@@ -40,6 +93,104 @@ class CodeIntelligenceService {
     } catch {
       return []; // No folding provider available
     }
+  }
+
+  /**
+   * Get the line number after the last import statement
+   * Returns 0 if no imports found or file is all imports
+   *
+   * @param content - File content
+   * @param languageId - Language identifier
+   */
+  getImportSectionEnd(content: string, languageId: string): number {
+    const patterns = IMPORT_PATTERNS[languageId];
+    if (!patterns) return 0;
+
+    const lines = content.split('\n');
+    let lastImportLine = -1;
+    let inMultiLineImport = false;
+    let inGoImportBlock = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const trimmed = line.trim();
+
+      // Skip empty lines and comments when tracking imports
+      if (trimmed === '' || this.isComment(trimmed, languageId)) {
+        continue;
+      }
+
+      // Handle Go's multi-line import block: import (...)
+      if (languageId === 'go') {
+        if (/^\s*import\s*\(\s*$/.test(line)) {
+          inGoImportBlock = true;
+          lastImportLine = i;
+          continue;
+        }
+        if (inGoImportBlock) {
+          lastImportLine = i;
+          if (trimmed === ')') {
+            inGoImportBlock = false;
+          }
+          continue;
+        }
+      }
+
+      // Handle multi-line imports (lines ending with comma or backslash, or unclosed parens)
+      if (inMultiLineImport) {
+        lastImportLine = i;
+        // Check if this line closes the import
+        const openParens = (line.match(/\(/g) || []).length;
+        const closeParens = (line.match(/\)/g) || []).length;
+        if (closeParens > openParens || (!line.endsWith(',') && !line.endsWith('\\'))) {
+          inMultiLineImport = false;
+        }
+        continue;
+      }
+
+      // Check if line matches any import pattern
+      const isImport = patterns.some(pattern => pattern.test(line));
+      if (isImport) {
+        lastImportLine = i;
+        // Check if this is a multi-line import
+        const openParens = (line.match(/\(/g) || []).length;
+        const closeParens = (line.match(/\)/g) || []).length;
+        if (openParens > closeParens || line.endsWith(',') || line.endsWith('\\')) {
+          inMultiLineImport = true;
+        }
+      }
+    }
+
+    // No imports found
+    if (lastImportLine === -1) return 0;
+
+    // Find the first non-empty, non-comment line after imports
+    for (let i = lastImportLine + 1; i < lines.length; i++) {
+      const trimmed = lines[i].trim();
+      if (trimmed !== '' && !this.isComment(trimmed, languageId)) {
+        // Return 1-based line number for separator insertion
+        return i + 1;
+      }
+    }
+
+    // File is all imports (no code after), don't add separator
+    return 0;
+  }
+
+  /**
+   * Check if a line is a comment
+   */
+  private isComment(trimmedLine: string, languageId: string): boolean {
+    // Single-line comments
+    if (trimmedLine.startsWith('//')) return true;
+    if (trimmedLine.startsWith('#') && ['python', 'ruby', 'shell', 'bash'].includes(languageId)) return true;
+    if (trimmedLine.startsWith('--') && languageId === 'lua') return true;
+
+    // Multi-line comment start (simplified - doesn't track state)
+    if (trimmedLine.startsWith('/*') || trimmedLine.startsWith('/**')) return true;
+    if (trimmedLine.startsWith('*')) return true; // Inside multi-line comment
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add automatic visual separation between import/require sections and main code
- Support multiple languages: JavaScript/TypeScript, Python, Java, Go, Rust, C/C++
- Handle multi-line imports and Go's `import (...)` blocks
- Merge import separators with existing symbol boundaries

## Changes
- `src/services/codeIntelligence.ts`: Added `IMPORT_PATTERNS`, `getImportSectionEnd()`, `isComment()`
- `src/commands/printFile.ts`: Integrated import section detection

Closes #12