### PR TITLE
feat(VSPRINT-014): Custom CSS themes and built-in print themes

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,8 +1,32 @@
 const esbuild = require('esbuild');
 const path = require('path');
+const fs = require('fs');
 
 const production = process.env.NODE_ENV === 'production';
 const watch = process.argv.includes('--watch');
+
+/**
+ * Copy theme CSS files to dist directory
+ */
+function copyThemes() {
+  const themesDir = path.join(__dirname, 'src', 'themes');
+  const distThemesDir = path.join(__dirname, 'dist', 'themes');
+
+  // Create dist/themes directory if it doesn't exist
+  if (!fs.existsSync(distThemesDir)) {
+    fs.mkdirSync(distThemesDir, { recursive: true });
+  }
+
+  // Copy all CSS files from src/themes to dist/themes
+  const themeFiles = fs.readdirSync(themesDir).filter(file => file.endsWith('.css'));
+
+  themeFiles.forEach(file => {
+    const srcPath = path.join(themesDir, file);
+    const destPath = path.join(distThemesDir, file);
+    fs.copyFileSync(srcPath, destPath);
+    console.log(`Copied theme: ${file}`);
+  });
+}
 
 async function build() {
   const ctx = await esbuild.context({
@@ -25,6 +49,9 @@ async function build() {
     await ctx.rebuild();
     await ctx.dispose();
   }
+
+  // Copy theme files after build
+  copyThemes();
 }
 
 build().catch((error) => {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,34 @@
           "default": "github-light",
           "description": "Syntax highlighting theme for printed code"
         },
+        "vsprint.builtinTheme": {
+          "type": "string",
+          "enum": [
+            "default",
+            "codeReview",
+            "minimal",
+            "documentation",
+            "grayscale"
+          ],
+          "default": "default",
+          "description": "Built-in print theme: default (standard), codeReview (wide margins), minimal (compact), documentation (readable), grayscale (B&W printer)"
+        },
+        "vsprint.customCss": {
+          "type": "string",
+          "default": "",
+          "description": "Path to custom CSS file for print customization (absolute or relative to workspace)"
+        },
+        "vsprint.colorScheme": {
+          "type": "string",
+          "enum": [
+            "light",
+            "dark",
+            "highContrast",
+            "grayscale"
+          ],
+          "default": "light",
+          "description": "Color scheme for print output: light, dark, highContrast, or grayscale"
+        },
         "vsprint.lineWrap": {
           "type": "string",
           "enum": [

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ColorScheme } from '../utils/cssLoader';
 
 /**
  * Print settings configuration
@@ -15,6 +16,9 @@ export interface PrintSettings {
   headerTemplate: string;
   footerTemplate: string;
   columns: 1 | 2 | 4;
+  customCss?: string;
+  colorScheme?: ColorScheme;
+  builtinTheme?: 'default' | 'codeReview' | 'minimal' | 'documentation' | 'grayscale';
 }
 
 /**
@@ -31,7 +35,10 @@ const DEFAULT_SETTINGS: PrintSettings = {
   showSeparators: false,
   headerTemplate: '{filename}',
   footerTemplate: 'Page {page} of {pages}',
-  columns: 1
+  columns: 1,
+  customCss: undefined,
+  colorScheme: undefined,
+  builtinTheme: 'default'
 };
 
 /**
@@ -54,6 +61,9 @@ export function getSettings(): PrintSettings {
     showSeparators: config.get<boolean>('showSeparators', DEFAULT_SETTINGS.showSeparators),
     headerTemplate: config.get<string>('header.template', DEFAULT_SETTINGS.headerTemplate),
     footerTemplate: config.get<string>('footer.template', DEFAULT_SETTINGS.footerTemplate),
-    columns: config.get<1 | 2 | 4>('columns', DEFAULT_SETTINGS.columns)
+    columns: config.get<1 | 2 | 4>('columns', DEFAULT_SETTINGS.columns),
+    customCss: config.get<string>('customCss') || DEFAULT_SETTINGS.customCss,
+    colorScheme: config.get<ColorScheme>('colorScheme') || DEFAULT_SETTINGS.colorScheme,
+    builtinTheme: config.get<'default' | 'codeReview' | 'minimal' | 'documentation' | 'grayscale'>('builtinTheme') || DEFAULT_SETTINGS.builtinTheme
   };
 }

--- a/src/renderers/htmlRenderer.ts
+++ b/src/renderers/htmlRenderer.ts
@@ -4,6 +4,8 @@ import { syntaxHighlighter } from '../services/syntaxHighlighter';
 import { FoldRange } from '../services/codeIntelligence';
 import { visualizeWhitespace } from '../utils/textTransform';
 import { pageLayoutService } from '../services/pageLayout';
+import { loadCustomCss, loadBuiltinTheme, combineCssStyles, BuiltinThemeName } from '../utils/cssLoader';
+import * as vscode from 'vscode';
 
 /**
  * Escape HTML entities to prevent XSS and rendering issues
@@ -56,6 +58,22 @@ function generateStyles(settings: PrintSettings, backgroundColor: string, foregr
 
   return `
     <style>
+      /* CSS Variable Hooks for Theme Customization */
+      :root {
+        --vsprint-bg-color: ${backgroundColor};
+        --vsprint-text-color: ${foregroundColor};
+        --vsprint-line-number-color: #999;
+        --vsprint-border-color: #ccc;
+        --vsprint-header-bg: transparent;
+        --vsprint-code-font: ${settings.fontFamily};
+        --vsprint-font-size: ${settings.fontSize}pt;
+        --vsprint-line-height: 1.5;
+        --vsprint-margin-top: 10mm;
+        --vsprint-margin-bottom: 10mm;
+        --vsprint-margin-left: 10mm;
+        --vsprint-margin-right: 10mm;
+      }
+
       * {
         margin: 0;
         padding: 0;
@@ -63,17 +81,18 @@ function generateStyles(settings: PrintSettings, backgroundColor: string, foregr
       }
 
       body {
-        font-family: ${settings.fontFamily};
-        font-size: ${settings.fontSize}pt;
-        line-height: 1.5;
-        color: ${foregroundColor};
-        background: ${backgroundColor};
+        font-family: var(--vsprint-code-font);
+        font-size: var(--vsprint-font-size);
+        line-height: var(--vsprint-line-height);
+        color: var(--vsprint-text-color);
+        background: var(--vsprint-bg-color);
       }
 
       .header {
         margin-bottom: 20px;
         padding-bottom: 10px;
-        border-bottom: 1px solid #ccc;
+        border-bottom: 1px solid var(--vsprint-border-color);
+        background-color: var(--vsprint-header-bg);
       }
 
       .header h1 {
@@ -91,7 +110,7 @@ function generateStyles(settings: PrintSettings, backgroundColor: string, foregr
         padding: 5px 0;
         font-size: ${settings.fontSize}pt;
         font-weight: bold;
-        border-bottom: 1px solid #ccc;
+        border-bottom: 1px solid var(--vsprint-border-color);
       }
 
       .page-footer {
@@ -99,7 +118,7 @@ function generateStyles(settings: PrintSettings, backgroundColor: string, foregr
         padding: 5px 0;
         font-size: ${settings.fontSize - 1}pt;
         text-align: center;
-        border-top: 1px solid #ccc;
+        border-top: 1px solid var(--vsprint-border-color);
         color: #666;
       }
 
@@ -115,8 +134,8 @@ function generateStyles(settings: PrintSettings, backgroundColor: string, foregr
       .line-number {
         text-align: right;
         padding-right: 10px;
-        color: #999;
-        border-right: 1px solid #ccc;
+        color: var(--vsprint-line-number-color);
+        border-right: 1px solid var(--vsprint-border-color);
         user-select: none;
         vertical-align: top;
         width: 50px;
@@ -143,7 +162,7 @@ function generateStyles(settings: PrintSettings, backgroundColor: string, foregr
       .footer {
         margin-top: 20px;
         padding-top: 10px;
-        border-top: 1px solid #ccc;
+        border-top: 1px solid var(--vsprint-border-color);
         text-align: center;
         font-size: ${settings.fontSize - 1}pt;
         color: #666;
@@ -345,7 +364,40 @@ export async function generatePrintHtml(
   // Apply syntax highlighting
   const highlightedCode = await syntaxHighlighter.highlight(processedContent, metadata.languageId, settings.theme);
 
-  const styles = generateStyles(settings, backgroundColor, foregroundColor);
+  // Generate base styles
+  const baseStyles = generateStyles(settings, backgroundColor, foregroundColor);
+
+  // Load custom CSS or built-in theme if specified
+  let additionalCss = '';
+
+  // Try to load custom CSS first (takes precedence)
+  if (settings.customCss && settings.customCss.trim()) {
+    try {
+      additionalCss = await loadCustomCss(settings.customCss);
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        `VSPrint: Failed to load custom CSS: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+  // If no custom CSS, try to load built-in theme
+  else if (settings.builtinTheme && settings.builtinTheme !== 'default') {
+    try {
+      additionalCss = await loadBuiltinTheme(settings.builtinTheme as BuiltinThemeName);
+    } catch (error) {
+      vscode.window.showWarningMessage(
+        `VSPrint: Failed to load built-in theme '${settings.builtinTheme}': ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  // Combine base styles with additional CSS and color scheme overrides
+  const finalStyles = combineCssStyles(
+    baseStyles,
+    additionalCss,
+    settings.colorScheme
+  );
+
   const header = generateHeader(metadata);
   const codeTable = generateCodeTable(highlightedCode, settings, true, symbolBoundaries);
   const footer = generateFooter();
@@ -371,7 +423,7 @@ export async function generatePrintHtml(
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${escapeHtml(metadata.fileName)} - Print</title>
-  ${styles}
+  ${finalStyles}
 </head>
 <body>
   ${header}

--- a/src/themes/codeReview.css
+++ b/src/themes/codeReview.css
@@ -1,0 +1,99 @@
+/**
+ * Code Review Theme
+ * Optimized for code reviews with wide margins for handwritten annotations
+ */
+
+:root {
+  /* Override base CSS variables for code review layout */
+  --vsprint-bg-color: #ffffff;
+  --vsprint-text-color: #24292e;
+  --vsprint-line-number-color: #0969da;
+  --vsprint-border-color: #d0d7de;
+  --vsprint-header-bg: #f6f8fa;
+  --vsprint-code-font: 'Consolas', 'Monaco', 'Courier New', monospace;
+
+  /* Code review specific variables */
+  --vsprint-margin-left: 35mm;
+  --vsprint-margin-right: 15mm;
+  --vsprint-font-size: 11pt;
+  --vsprint-line-height: 1.8;
+}
+
+@page {
+  margin: 10mm 15mm 10mm 35mm;
+  size: A4;
+}
+
+body {
+  font-size: var(--vsprint-font-size);
+  line-height: var(--vsprint-line-height);
+}
+
+.header {
+  background-color: var(--vsprint-header-bg);
+  padding: 15px;
+  border-radius: 4px;
+  margin-bottom: 25px;
+}
+
+.header h1 {
+  font-size: 14pt;
+  font-weight: 600;
+  color: var(--vsprint-text-color);
+}
+
+.header .metadata {
+  margin-top: 8px;
+  font-size: 9pt;
+  color: #57606a;
+}
+
+.line-number {
+  font-weight: 600;
+  color: var(--vsprint-line-number-color);
+  background-color: #f6f8fa;
+  padding-right: 15px;
+  padding-left: 8px;
+  width: 60px;
+  border-right: 2px solid var(--vsprint-border-color);
+}
+
+.code-line {
+  padding-left: 15px;
+}
+
+.code-line pre {
+  font-size: var(--vsprint-font-size);
+  line-height: var(--vsprint-line-height);
+}
+
+/* Enhanced separators for clear function boundaries */
+.separator td {
+  border-top: 2px dashed #d0d7de;
+  padding-top: 12px;
+  height: 20px;
+}
+
+/* Make important code constructs stand out */
+tr:hover {
+  background-color: #f6f8fa;
+}
+
+/* Page footer with review metadata */
+.footer, .page-footer {
+  font-size: 9pt;
+  color: #57606a;
+  border-top: 1px solid var(--vsprint-border-color);
+}
+
+@media print {
+  /* Ensure annotations margin is preserved */
+  @page {
+    margin-left: 35mm !important;
+  }
+
+  /* Prevent breaks within code blocks */
+  .code-container tr {
+    page-break-inside: avoid;
+  }
+}

--- a/src/themes/documentation.css
+++ b/src/themes/documentation.css
@@ -1,0 +1,118 @@
+/**
+ * Documentation Theme
+ * Optimized for readable code documentation with larger text and generous spacing
+ */
+
+:root {
+  /* Documentation theme CSS variables */
+  --vsprint-bg-color: #fefefe;
+  --vsprint-text-color: #2c3e50;
+  --vsprint-line-number-color: #95a5a6;
+  --vsprint-border-color: #bdc3c7;
+  --vsprint-header-bg: #ecf0f1;
+  --vsprint-code-font: 'Consolas', 'Monaco', 'Courier New', monospace;
+  --vsprint-comment-font: 'Georgia', 'Times New Roman', serif;
+
+  /* Generous spacing for readability */
+  --vsprint-margin-top: 15mm;
+  --vsprint-margin-bottom: 15mm;
+  --vsprint-margin-left: 15mm;
+  --vsprint-margin-right: 15mm;
+  --vsprint-font-size: 11pt;
+  --vsprint-line-height: 1.8;
+}
+
+@page {
+  margin: 15mm;
+  size: A4;
+}
+
+body {
+  font-size: var(--vsprint-font-size);
+  line-height: var(--vsprint-line-height);
+  color: var(--vsprint-text-color);
+}
+
+.header {
+  background-color: var(--vsprint-header-bg);
+  padding: 20px;
+  border-radius: 6px;
+  margin-bottom: 30px;
+  border-left: 4px solid #3498db;
+}
+
+.header h1 {
+  font-size: 16pt;
+  font-weight: 600;
+  color: #34495e;
+  margin-bottom: 10px;
+}
+
+.header .metadata {
+  font-size: 10pt;
+  color: #7f8c8d;
+  line-height: 1.6;
+}
+
+.line-number {
+  color: var(--vsprint-line-number-color);
+  font-size: 9pt;
+  padding-right: 12px;
+  padding-left: 8px;
+  width: 55px;
+  border-right: 1px solid var(--vsprint-border-color);
+  background-color: #f8f9fa;
+}
+
+.code-line {
+  padding-left: 15px;
+}
+
+.code-line pre {
+  font-size: var(--vsprint-font-size);
+  line-height: var(--vsprint-line-height);
+  font-family: var(--vsprint-code-font);
+}
+
+/* Enhanced separators for documentation sections */
+.separator td {
+  border-top: 1px solid var(--vsprint-border-color);
+  padding-top: 15px;
+  padding-bottom: 5px;
+}
+
+/* Footer styling for documentation */
+.footer, .page-footer {
+  font-size: 9pt;
+  color: #7f8c8d;
+  border-top: 2px solid var(--vsprint-border-color);
+  padding-top: 10px;
+}
+
+.page-footer {
+  margin-top: 15px;
+}
+
+/* Enhanced readability for comments (if syntax highlighting supports it) */
+.comment {
+  font-family: var(--vsprint-comment-font);
+  font-style: italic;
+  color: #16a085;
+}
+
+@media print {
+  /* Ensure generous margins for readability */
+  @page {
+    margin: 15mm !important;
+  }
+
+  /* Prevent breaks in the middle of code blocks */
+  .code-container tr {
+    page-break-inside: avoid;
+  }
+
+  /* Keep headers with content */
+  .header {
+    page-break-after: avoid;
+  }
+}

--- a/src/themes/grayscale.css
+++ b/src/themes/grayscale.css
@@ -1,0 +1,116 @@
+/**
+ * Grayscale Theme
+ * Optimized for black & white printers with high contrast and no color
+ */
+
+:root {
+  /* Grayscale theme CSS variables */
+  --vsprint-bg-color: #ffffff;
+  --vsprint-text-color: #000000;
+  --vsprint-line-number-color: #666666;
+  --vsprint-border-color: #333333;
+  --vsprint-header-bg: #f5f5f5;
+  --vsprint-code-font: 'Consolas', 'Monaco', 'Courier New', monospace;
+
+  --vsprint-margin-top: 10mm;
+  --vsprint-margin-bottom: 10mm;
+  --vsprint-margin-left: 10mm;
+  --vsprint-margin-right: 10mm;
+  --vsprint-font-size: 10pt;
+  --vsprint-line-height: 1.5;
+}
+
+@page {
+  margin: 10mm;
+  size: A4;
+}
+
+body {
+  font-size: var(--vsprint-font-size);
+  line-height: var(--vsprint-line-height);
+  color: var(--vsprint-text-color);
+}
+
+.header {
+  background-color: var(--vsprint-header-bg);
+  padding: 12px;
+  margin-bottom: 20px;
+  border: 2px solid var(--vsprint-border-color);
+}
+
+.header h1 {
+  font-size: 13pt;
+  font-weight: bold;
+  color: var(--vsprint-text-color);
+}
+
+.header .metadata {
+  font-size: 9pt;
+  color: #333333;
+  margin-top: 6px;
+}
+
+.line-number {
+  color: var(--vsprint-line-number-color);
+  font-weight: normal;
+  padding-right: 10px;
+  padding-left: 5px;
+  width: 50px;
+  border-right: 2px solid var(--vsprint-border-color);
+}
+
+.code-line {
+  padding-left: 10px;
+}
+
+.code-line pre {
+  font-size: var(--vsprint-font-size);
+  line-height: var(--vsprint-line-height);
+}
+
+/* Strong separators for B&W printing */
+.separator td {
+  border-top: 3px double var(--vsprint-border-color);
+  padding-top: 10px;
+}
+
+.footer, .page-footer {
+  font-size: 9pt;
+  color: #333333;
+  border-top: 2px solid var(--vsprint-border-color);
+}
+
+@media print {
+  /* High contrast for B&W printers */
+  * {
+    color: #000000 !important;
+    background-color: #ffffff !important;
+  }
+
+  .header {
+    border: 2px solid #000000 !important;
+    background-color: #ffffff !important;
+  }
+
+  .line-number {
+    color: #666666 !important;
+    border-right: 2px solid #000000 !important;
+  }
+
+  .separator td {
+    border-top: 3px double #000000 !important;
+  }
+
+  .footer, .page-footer {
+    border-top: 2px solid #000000 !important;
+  }
+
+  /* Force bold/italic instead of colors for syntax */
+  .keyword, .type {
+    font-weight: bold !important;
+  }
+
+  .comment {
+    font-style: italic !important;
+  }
+}

--- a/src/themes/minimal.css
+++ b/src/themes/minimal.css
@@ -1,0 +1,91 @@
+/**
+ * Minimal Theme
+ * Clean, distraction-free layout with maximum code density
+ */
+
+:root {
+  /* Minimal theme CSS variables */
+  --vsprint-bg-color: #ffffff;
+  --vsprint-text-color: #000000;
+  --vsprint-line-number-color: #cccccc;
+  --vsprint-border-color: transparent;
+  --vsprint-header-bg: transparent;
+  --vsprint-code-font: 'Consolas', 'Monaco', 'Courier New', monospace;
+
+  /* Tight spacing for maximum density */
+  --vsprint-margin-top: 5mm;
+  --vsprint-margin-bottom: 5mm;
+  --vsprint-margin-left: 8mm;
+  --vsprint-margin-right: 8mm;
+  --vsprint-font-size: 9pt;
+  --vsprint-line-height: 1.3;
+}
+
+@page {
+  margin: 5mm 8mm;
+  size: A4;
+}
+
+body {
+  font-size: var(--vsprint-font-size);
+  line-height: var(--vsprint-line-height);
+}
+
+.header {
+  border: none;
+  padding-bottom: 8px;
+  margin-bottom: 12px;
+}
+
+.header h1 {
+  font-size: 11pt;
+  font-weight: 500;
+  color: var(--vsprint-text-color);
+}
+
+.header .metadata {
+  font-size: 8pt;
+  color: #666666;
+  margin-top: 4px;
+}
+
+.line-number {
+  color: var(--vsprint-line-number-color);
+  padding-right: 8px;
+  padding-left: 0;
+  width: 40px;
+  border: none;
+  font-size: 8pt;
+}
+
+.code-line {
+  padding-left: 8px;
+}
+
+.code-line pre {
+  font-size: var(--vsprint-font-size);
+  line-height: var(--vsprint-line-height);
+}
+
+/* No separators for maximum density */
+.separator {
+  display: none;
+}
+
+.footer, .page-footer {
+  border: none;
+  font-size: 8pt;
+  color: #999999;
+}
+
+@media print {
+  /* Remove all borders and backgrounds */
+  * {
+    background: none !important;
+    border-color: transparent !important;
+  }
+
+  .line-number {
+    color: #cccccc !important;
+  }
+}

--- a/src/utils/cssLoader.ts
+++ b/src/utils/cssLoader.ts
@@ -1,0 +1,211 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * Maximum allowed custom CSS file size (1MB)
+ */
+const MAX_CSS_SIZE = 1024 * 1024;
+
+/**
+ * Built-in theme names and their corresponding CSS file names
+ */
+export const BUILTIN_THEMES = {
+  codeReview: 'codeReview.css',
+  minimal: 'minimal.css',
+  documentation: 'documentation.css',
+  grayscale: 'grayscale.css'
+} as const;
+
+export type BuiltinThemeName = keyof typeof BUILTIN_THEMES;
+
+/**
+ * Color scheme options for automatic theme adjustment
+ */
+export type ColorScheme = 'light' | 'dark' | 'highContrast' | 'grayscale';
+
+/**
+ * Load custom CSS file from user-specified path
+ *
+ * @param cssPath - Absolute or relative path to CSS file
+ * @returns CSS content as string
+ * @throws Error if file doesn't exist, is too large, or can't be read
+ */
+export async function loadCustomCss(cssPath: string): Promise<string> {
+  try {
+    // Resolve path relative to workspace if not absolute
+    let resolvedPath = cssPath;
+    if (!path.isAbsolute(cssPath)) {
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      if (workspaceFolder) {
+        resolvedPath = path.join(workspaceFolder.uri.fsPath, cssPath);
+      } else {
+        throw new Error('Cannot resolve relative path: no workspace folder open');
+      }
+    }
+
+    // Check if file exists
+    const uri = vscode.Uri.file(resolvedPath);
+    let stats;
+    try {
+      stats = await vscode.workspace.fs.stat(uri);
+    } catch (error) {
+      throw new Error(`Custom CSS file not found: ${resolvedPath}`);
+    }
+
+    // Check file size
+    if (stats.size > MAX_CSS_SIZE) {
+      vscode.window.showWarningMessage(
+        `Custom CSS file is very large (${Math.round(stats.size / 1024)}KB). This may affect performance.`
+      );
+    }
+
+    // Read file content
+    const content = await vscode.workspace.fs.readFile(uri);
+    const cssText = Buffer.from(content).toString('utf8');
+
+    // Basic validation - check if it looks like CSS
+    if (!cssText.trim()) {
+      throw new Error('Custom CSS file is empty');
+    }
+
+    return cssText;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`Failed to load custom CSS: ${String(error)}`);
+  }
+}
+
+/**
+ * Load a built-in theme CSS file
+ *
+ * @param themeName - Name of the built-in theme
+ * @returns CSS content as string
+ * @throws Error if theme file can't be loaded
+ */
+export async function loadBuiltinTheme(themeName: BuiltinThemeName): Promise<string> {
+  try {
+    const extensionPath = vscode.extensions.getExtension('richardwhiteii.vsprint')?.extensionPath;
+    if (!extensionPath) {
+      throw new Error('Extension path not found');
+    }
+
+    const themePath = path.join(extensionPath, 'dist', 'themes', BUILTIN_THEMES[themeName]);
+
+    // Try to read the file synchronously for built-in themes
+    // (they should always be present in the extension package)
+    if (!fs.existsSync(themePath)) {
+      throw new Error(`Built-in theme file not found: ${themePath}`);
+    }
+
+    const cssText = fs.readFileSync(themePath, 'utf8');
+    return cssText;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`Failed to load built-in theme: ${String(error)}`);
+  }
+}
+
+/**
+ * Get CSS variable overrides for color schemes
+ *
+ * @param colorScheme - Color scheme to apply
+ * @returns CSS string with variable overrides
+ */
+export function getColorSchemeOverrides(colorScheme: ColorScheme): string {
+  switch (colorScheme) {
+    case 'light':
+      return `
+:root {
+  --vsprint-bg-color: #ffffff;
+  --vsprint-text-color: #24292e;
+  --vsprint-line-number-color: #57606a;
+  --vsprint-border-color: #d0d7de;
+  --vsprint-header-bg: #f6f8fa;
+}`;
+
+    case 'dark':
+      return `
+:root {
+  --vsprint-bg-color: #0d1117;
+  --vsprint-text-color: #e6edf3;
+  --vsprint-line-number-color: #7d8590;
+  --vsprint-border-color: #30363d;
+  --vsprint-header-bg: #161b22;
+}`;
+
+    case 'highContrast':
+      return `
+:root {
+  --vsprint-bg-color: #000000;
+  --vsprint-text-color: #ffffff;
+  --vsprint-line-number-color: #ffff00;
+  --vsprint-border-color: #ffffff;
+  --vsprint-header-bg: #1a1a1a;
+}
+
+body {
+  border: 2px solid #ffffff;
+}
+
+.line-number {
+  border-right: 2px solid #ffffff;
+  font-weight: bold;
+}
+
+.header, .footer {
+  border-color: #ffffff;
+}`;
+
+    case 'grayscale':
+      return `
+:root {
+  --vsprint-bg-color: #ffffff;
+  --vsprint-text-color: #000000;
+  --vsprint-line-number-color: #666666;
+  --vsprint-border-color: #333333;
+  --vsprint-header-bg: #f5f5f5;
+}
+
+* {
+  color: #000000 !important;
+}
+
+.line-number {
+  color: #666666 !important;
+}`;
+
+    default:
+      return '';
+  }
+}
+
+/**
+ * Combine base CSS with custom/theme CSS and color scheme overrides
+ *
+ * @param baseStyles - Base CSS styles
+ * @param additionalCss - Optional custom or theme CSS
+ * @param colorScheme - Optional color scheme to apply
+ * @returns Combined CSS string
+ */
+export function combineCssStyles(
+  baseStyles: string,
+  additionalCss?: string,
+  colorScheme?: ColorScheme
+): string {
+  const parts = [baseStyles];
+
+  if (additionalCss) {
+    parts.push('\n/* Custom/Theme CSS */\n', additionalCss);
+  }
+
+  if (colorScheme) {
+    parts.push('\n/* Color Scheme Overrides */\n', getColorSchemeOverrides(colorScheme));
+  }
+
+  return parts.join('\n');
+}


### PR DESCRIPTION
## Summary
- Add custom CSS support via `vsprint.customCss` setting
- Create 4 built-in themes: codeReview, minimal, documentation, grayscale
- Add `vsprint.colorScheme` setting (light/dark/highContrast/grayscale)
- Implement CSS variable hooks for easy theme customization
- Integrate theme loading with htmlRenderer

## Test plan
- [ ] Set custom CSS path and verify it's applied to output
- [ ] Select each built-in theme and verify rendering
- [ ] Change color scheme and verify colors update
- [ ] Verify invalid CSS path shows warning

Closes #26