### PR TITLE
feat: VSPRINT-016 Git diff printing with unified and side-by-side views

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "activationEvents": [
     "onCommand:vsprint.printFile",
     "onCommand:vsprint.printSelection",
+    "onCommand:vsprint.printDiff",
     "onCommand:vsprint.exportHtml",
     "onCommand:vsprint.exportPdf",
     "onCommand:vsprint.saveProfile",
@@ -30,6 +31,10 @@
       {
         "command": "vsprint.printSelection",
         "title": "VSPrint: Print Selection"
+      },
+      {
+        "command": "vsprint.printDiff",
+        "title": "VSPrint: Print Git Diff"
       },
       {
         "command": "vsprint.exportHtml",
@@ -328,6 +333,27 @@
           "type": "boolean",
           "default": true,
           "description": "Respect .gitignore patterns when printing folders. If true, files ignored by git will be excluded from print output."
+        },
+        "vsprint.diff.mode": {
+          "type": "string",
+          "enum": [
+            "unified",
+            "sideBySide"
+          ],
+          "default": "sideBySide",
+          "description": "Git diff display mode: unified (single column) or sideBySide (two column comparison)"
+        },
+        "vsprint.diff.showLineNumbers": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show line numbers in git diff output"
+        },
+        "vsprint.diff.contextLines": {
+          "type": "number",
+          "default": 3,
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Number of context lines to show around changes in git diff"
         }
       }
     }

--- a/src/commands/printDiff.ts
+++ b/src/commands/printDiff.ts
@@ -1,0 +1,326 @@
+import * as vscode from 'vscode';
+import { logger } from '../utils/logger';
+import { generateDiffHtml } from '../renderers/diffRenderer';
+import { getSettings } from '../config/settings';
+import { printHtml } from '../renderers/printerRenderer';
+
+/**
+ * Git API types from vscode.git extension
+ */
+interface GitExtension {
+  getAPI(version: 1): GitAPI;
+}
+
+interface GitAPI {
+  repositories: Repository[];
+}
+
+interface Repository {
+  rootUri: vscode.Uri;
+  state: {
+    workingTreeChanges: Change[];
+    indexChanges: Change[];
+  };
+  diffWithHEAD(path: string): Promise<string>;
+  diffIndexWithHEAD(path: string): Promise<string>;
+  diffWith(ref: string, path: string): Promise<string>;
+}
+
+interface Change {
+  uri: vscode.Uri;
+  originalUri?: vscode.Uri;
+  status: number;
+}
+
+/**
+ * Diff type selection options
+ */
+enum DiffType {
+  UNSTAGED = 'Unstaged Changes',
+  STAGED = 'Staged Changes',
+  FILE_HEAD = 'Current File vs HEAD'
+}
+
+/**
+ * Get the Git API from VS Code Git extension
+ */
+async function getGitAPI(): Promise<GitAPI | undefined> {
+  try {
+    const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git');
+
+    if (!gitExtension) {
+      logger.warn('Git extension not found');
+      return undefined;
+    }
+
+    if (!gitExtension.isActive) {
+      await gitExtension.activate();
+    }
+
+    const git = gitExtension.exports.getAPI(1);
+    return git;
+  } catch (error) {
+    logger.error('Failed to get Git API', error as Error);
+    return undefined;
+  }
+}
+
+/**
+ * Find the repository for a given file URI
+ */
+function findRepository(git: GitAPI, fileUri: vscode.Uri): Repository | undefined {
+  return git.repositories.find(repo => {
+    const repoPath = repo.rootUri.fsPath;
+    const filePath = fileUri.fsPath;
+    return filePath.startsWith(repoPath);
+  });
+}
+
+/**
+ * Parse unified diff output into structured format
+ */
+interface DiffHunk {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: DiffLine[];
+}
+
+interface DiffLine {
+  type: 'add' | 'delete' | 'context';
+  content: string;
+  oldLineNumber?: number;
+  newLineNumber?: number;
+}
+
+function parseDiff(diffText: string): DiffHunk[] {
+  const hunks: DiffHunk[] = [];
+  const lines = diffText.split('\n');
+
+  let currentHunk: DiffHunk | null = null;
+  let oldLineNum = 0;
+  let newLineNum = 0;
+
+  for (const line of lines) {
+    // Parse hunk header: @@ -oldStart,oldLines +newStart,newLines @@
+    const hunkMatch = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+
+    if (hunkMatch) {
+      // Save previous hunk
+      if (currentHunk) {
+        hunks.push(currentHunk);
+      }
+
+      // Start new hunk
+      const oldStart = parseInt(hunkMatch[1], 10);
+      const oldLines = parseInt(hunkMatch[2] || '1', 10);
+      const newStart = parseInt(hunkMatch[3], 10);
+      const newLines = parseInt(hunkMatch[4] || '1', 10);
+
+      oldLineNum = oldStart;
+      newLineNum = newStart;
+
+      currentHunk = {
+        oldStart,
+        oldLines,
+        newStart,
+        newLines,
+        lines: []
+      };
+      continue;
+    }
+
+    // Skip diff header lines
+    if (line.startsWith('diff --git') ||
+        line.startsWith('index ') ||
+        line.startsWith('---') ||
+        line.startsWith('+++')) {
+      continue;
+    }
+
+    // Parse diff lines
+    if (currentHunk) {
+      if (line.startsWith('+')) {
+        currentHunk.lines.push({
+          type: 'add',
+          content: line.substring(1),
+          newLineNumber: newLineNum++
+        });
+      } else if (line.startsWith('-')) {
+        currentHunk.lines.push({
+          type: 'delete',
+          content: line.substring(1),
+          oldLineNumber: oldLineNum++
+        });
+      } else if (line.startsWith(' ')) {
+        currentHunk.lines.push({
+          type: 'context',
+          content: line.substring(1),
+          oldLineNumber: oldLineNum++,
+          newLineNumber: newLineNum++
+        });
+      }
+    }
+  }
+
+  // Save last hunk
+  if (currentHunk) {
+    hunks.push(currentHunk);
+  }
+
+  return hunks;
+}
+
+/**
+ * Get diff for the current file
+ */
+async function getDiffForFile(
+  repo: Repository,
+  fileUri: vscode.Uri,
+  diffType: DiffType
+): Promise<string> {
+  const relativePath = vscode.workspace.asRelativePath(fileUri, false);
+
+  try {
+    switch (diffType) {
+      case DiffType.UNSTAGED:
+        return await repo.diffWithHEAD(relativePath);
+
+      case DiffType.STAGED:
+        return await repo.diffIndexWithHEAD(relativePath);
+
+      case DiffType.FILE_HEAD:
+      default:
+        return await repo.diffWithHEAD(relativePath);
+    }
+  } catch (error) {
+    logger.error(`Failed to get diff for ${relativePath}`, error as Error);
+    throw error;
+  }
+}
+
+/**
+ * Command handler for printing git diff
+ */
+export async function printDiffCommand(): Promise<void> {
+  logger.info('Print Diff command invoked');
+
+  // Get the active text editor
+  const editor = vscode.window.activeTextEditor;
+
+  if (!editor) {
+    const errorMessage = 'No active file to diff. Please open a file first.';
+    logger.warn(errorMessage);
+    vscode.window.showErrorMessage(errorMessage);
+    return;
+  }
+
+  try {
+    // Get Git API
+    const git = await getGitAPI();
+
+    if (!git) {
+      vscode.window.showErrorMessage('Git extension is not available. Please ensure Git is installed and the Git extension is enabled.');
+      return;
+    }
+
+    // Find repository for current file
+    const fileUri = editor.document.uri;
+    const repo = findRepository(git, fileUri);
+
+    if (!repo) {
+      vscode.window.showWarningMessage('Current file is not in a Git repository.');
+      return;
+    }
+
+    // Show QuickPick for diff type selection
+    const diffTypeOptions = [
+      {
+        label: DiffType.UNSTAGED,
+        description: 'Show unstaged changes (working tree vs HEAD)',
+        value: DiffType.UNSTAGED
+      },
+      {
+        label: DiffType.STAGED,
+        description: 'Show staged changes (index vs HEAD)',
+        value: DiffType.STAGED
+      },
+      {
+        label: DiffType.FILE_HEAD,
+        description: 'Show all changes (current file vs HEAD)',
+        value: DiffType.FILE_HEAD
+      }
+    ];
+
+    const selected = await vscode.window.showQuickPick(diffTypeOptions, {
+      placeHolder: 'Select diff type to print',
+      ignoreFocusOut: false
+    });
+
+    if (!selected) {
+      logger.info('Diff type selection cancelled');
+      return;
+    }
+
+    // Get diff text
+    const diffText = await getDiffForFile(repo, fileUri, selected.value);
+
+    if (!diffText || diffText.trim().length === 0) {
+      vscode.window.showInformationMessage('No changes to display for the selected diff type.');
+      logger.info('No changes found for diff');
+      return;
+    }
+
+    // Parse diff
+    const hunks = parseDiff(diffText);
+    logger.info(`Parsed ${hunks.length} diff hunk(s)`);
+
+    // Get settings
+    const settings = getSettings();
+
+    // Get file info
+    const fileName = editor.document.fileName.split(/[\\/]/).pop() || 'Unknown';
+    const filePath = editor.document.uri.fsPath;
+
+    // Generate HTML
+    const html = await generateDiffHtml(
+      hunks,
+      fileName,
+      filePath,
+      selected.label,
+      settings
+    );
+
+    logger.info(`Diff HTML generated successfully (${html.length} bytes)`);
+
+    // Print via browser
+    await printHtml(html, `${fileName} - Diff`);
+
+    logger.info('Print Diff command completed successfully');
+
+  } catch (error) {
+    const errorMessage = 'Failed to print diff';
+    logger.error(errorMessage, error as Error);
+    vscode.window.showErrorMessage(`${errorMessage}: ${(error as Error).message}`);
+    throw error;
+  }
+}
+
+/**
+ * Register the print diff command
+ */
+export function registerPrintDiffCommand(context: vscode.ExtensionContext): void {
+  const disposable = vscode.commands.registerCommand(
+    'vsprint.printDiff',
+    printDiffCommand
+  );
+
+  context.subscriptions.push(disposable);
+  logger.info('Print Diff command registered');
+}
+
+/**
+ * Export types for use in diffRenderer
+ */
+export type { DiffHunk, DiffLine };

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -33,6 +33,11 @@ export interface PrintSettings {
   };
   exclude?: string[];
   respectGitignore?: boolean;
+  diff?: {
+    mode: 'unified' | 'sideBySide';
+    showLineNumbers: boolean;
+    contextLines: number;
+  };
 }
 
 /**
@@ -64,7 +69,12 @@ const DEFAULT_SETTINGS: PrintSettings = {
     position: 'header'
   },
   exclude: [],
-  respectGitignore: true
+  respectGitignore: true,
+  diff: {
+    mode: 'sideBySide',
+    showLineNumbers: true,
+    contextLines: 3
+  }
 };
 
 /**
@@ -102,6 +112,11 @@ export function getSettings(): PrintSettings {
       position: config.get<BrandingPosition>('branding.position', DEFAULT_SETTINGS.branding!.position)
     },
     exclude: config.get<string[]>('exclude', DEFAULT_SETTINGS.exclude!),
-    respectGitignore: config.get<boolean>('respectGitignore', DEFAULT_SETTINGS.respectGitignore!)
+    respectGitignore: config.get<boolean>('respectGitignore', DEFAULT_SETTINGS.respectGitignore!),
+    diff: {
+      mode: config.get<'unified' | 'sideBySide'>('diff.mode', DEFAULT_SETTINGS.diff!.mode),
+      showLineNumbers: config.get<boolean>('diff.showLineNumbers', DEFAULT_SETTINGS.diff!.showLineNumbers),
+      contextLines: config.get<number>('diff.contextLines', DEFAULT_SETTINGS.diff!.contextLines)
+    }
   };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { logger } from './utils/logger';
 import { registerPrintFileCommand } from './commands/printFile';
 import { registerPrintSelectionCommand } from './commands/printSelection';
+import { registerPrintDiffCommand } from './commands/printDiff';
 import { registerExportHtmlCommand } from './commands/exportHtml';
 import { registerExportPdfCommand } from './commands/exportPdf';
 import { getTempFiles, clearTempFileTracker } from './renderers/printerRenderer';
@@ -21,6 +22,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // Register commands
     registerPrintFileCommand(context);
     registerPrintSelectionCommand(context);
+    registerPrintDiffCommand(context);
     registerExportHtmlCommand(context);
     registerExportPdfCommand(context);
 

--- a/src/renderers/diffRenderer.ts
+++ b/src/renderers/diffRenderer.ts
@@ -1,0 +1,460 @@
+import { PrintSettings } from '../config/settings';
+import { DiffHunk, DiffLine } from '../commands/printDiff';
+
+/**
+ * Escape HTML entities to prevent XSS and rendering issues
+ */
+function escapeHtml(text: string): string {
+  const entityMap: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+
+  return text.replace(/[&<>"']/g, (char) => entityMap[char]);
+}
+
+/**
+ * Generate CSS styles for diff rendering
+ */
+function generateDiffStyles(settings: PrintSettings): string {
+  return `
+    <style>
+      /* CSS Variable Hooks */
+      :root {
+        --vsprint-diff-add-bg: #e6ffed;
+        --vsprint-diff-add-text: #24292e;
+        --vsprint-diff-delete-bg: #ffeef0;
+        --vsprint-diff-delete-text: #24292e;
+        --vsprint-diff-context-bg: #ffffff;
+        --vsprint-diff-context-text: #24292e;
+        --vsprint-diff-line-number-bg: #f6f8fa;
+        --vsprint-diff-line-number-text: #57606a;
+        --vsprint-diff-border-color: #d0d7de;
+        --vsprint-font-size: ${settings.fontSize}pt;
+        --vsprint-code-font: ${settings.fontFamily};
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: var(--vsprint-code-font);
+        font-size: var(--vsprint-font-size);
+        line-height: 1.5;
+        color: var(--vsprint-diff-context-text);
+        background: white;
+        padding: 20px;
+      }
+
+      .diff-header {
+        margin-bottom: 20px;
+        padding-bottom: 10px;
+        border-bottom: 2px solid var(--vsprint-diff-border-color);
+      }
+
+      .diff-header h1 {
+        font-size: ${settings.fontSize + 4}pt;
+        margin-bottom: 5px;
+        color: #24292e;
+      }
+
+      .diff-header .metadata {
+        font-size: ${settings.fontSize - 1}pt;
+        color: #57606a;
+      }
+
+      .diff-hunk {
+        margin-bottom: 20px;
+        border: 1px solid var(--vsprint-diff-border-color);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+
+      .hunk-header {
+        background-color: #f6f8fa;
+        padding: 5px 10px;
+        font-family: var(--vsprint-code-font);
+        font-size: ${settings.fontSize - 1}pt;
+        color: #57606a;
+        border-bottom: 1px solid var(--vsprint-diff-border-color);
+      }
+
+      /* Unified diff styles */
+      .diff-unified {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--vsprint-code-font);
+      }
+
+      .diff-unified td {
+        padding: 0 5px;
+        vertical-align: top;
+        white-space: pre;
+        font-family: var(--vsprint-code-font);
+      }
+
+      .diff-unified .line-number {
+        width: 50px;
+        text-align: right;
+        background-color: var(--vsprint-diff-line-number-bg);
+        color: var(--vsprint-diff-line-number-text);
+        border-right: 1px solid var(--vsprint-diff-border-color);
+        user-select: none;
+      }
+
+      .diff-unified .line-content {
+        padding-left: 10px;
+      }
+
+      .diff-unified .add-line {
+        background-color: var(--vsprint-diff-add-bg);
+      }
+
+      .diff-unified .delete-line {
+        background-color: var(--vsprint-diff-delete-bg);
+      }
+
+      .diff-unified .context-line {
+        background-color: var(--vsprint-diff-context-bg);
+      }
+
+      .diff-unified .line-marker {
+        display: inline-block;
+        width: 1em;
+        color: #57606a;
+      }
+
+      /* Side-by-side diff styles */
+      .diff-side-by-side {
+        width: 100%;
+        border-collapse: collapse;
+        table-layout: fixed;
+      }
+
+      .diff-side-by-side td {
+        padding: 0 5px;
+        vertical-align: top;
+        white-space: pre;
+        font-family: var(--vsprint-code-font);
+        width: 50%;
+      }
+
+      .diff-side-by-side .old-line-number,
+      .diff-side-by-side .new-line-number {
+        width: 50px;
+        text-align: right;
+        background-color: var(--vsprint-diff-line-number-bg);
+        color: var(--vsprint-diff-line-number-text);
+        border-right: 1px solid var(--vsprint-diff-border-color);
+        user-select: none;
+      }
+
+      .diff-side-by-side .old-content,
+      .diff-side-by-side .new-content {
+        padding-left: 10px;
+      }
+
+      .diff-side-by-side .old-content {
+        border-right: 1px solid var(--vsprint-diff-border-color);
+      }
+
+      .diff-side-by-side .delete-line-old {
+        background-color: var(--vsprint-diff-delete-bg);
+      }
+
+      .diff-side-by-side .add-line-new {
+        background-color: var(--vsprint-diff-add-bg);
+      }
+
+      .diff-side-by-side .context-line-old,
+      .diff-side-by-side .context-line-new {
+        background-color: var(--vsprint-diff-context-bg);
+      }
+
+      .diff-side-by-side .empty-line {
+        background-color: #fafbfc;
+      }
+
+      .footer {
+        margin-top: 20px;
+        padding-top: 10px;
+        border-top: 1px solid var(--vsprint-diff-border-color);
+        text-align: center;
+        font-size: ${settings.fontSize - 1}pt;
+        color: #57606a;
+      }
+
+      @media print {
+        @page {
+          margin: 1in;
+        }
+
+        body {
+          background: none;
+          padding: 0;
+        }
+
+        .diff-hunk {
+          page-break-inside: avoid;
+        }
+      }
+    </style>
+  `;
+}
+
+/**
+ * Generate diff header HTML
+ */
+function generateDiffHeader(fileName: string, filePath: string, diffType: string): string {
+  return `
+    <div class="diff-header">
+      <h1>${escapeHtml(fileName)}</h1>
+      <div class="metadata">
+        <strong>Path:</strong> ${escapeHtml(filePath)} |
+        <strong>Diff Type:</strong> ${escapeHtml(diffType)}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Generate unified diff view for a hunk
+ */
+function generateUnifiedHunk(hunk: DiffHunk, settings: PrintSettings): string {
+  let html = '<div class="diff-hunk">\n';
+
+  // Hunk header
+  html += `  <div class="hunk-header">@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@</div>\n`;
+
+  // Diff table
+  html += '  <table class="diff-unified">\n';
+
+  for (const line of hunk.lines) {
+    const lineClass = `${line.type}-line`;
+    let lineNumber = '';
+    let marker = '';
+
+    if (line.type === 'add') {
+      lineNumber = settings.showLineNumbers && line.newLineNumber ? String(line.newLineNumber) : '';
+      marker = '+';
+    } else if (line.type === 'delete') {
+      lineNumber = settings.showLineNumbers && line.oldLineNumber ? String(line.oldLineNumber) : '';
+      marker = '-';
+    } else {
+      lineNumber = settings.showLineNumbers && line.oldLineNumber ? String(line.oldLineNumber) : '';
+      marker = ' ';
+    }
+
+    const content = escapeHtml(line.content);
+
+    if (settings.showLineNumbers) {
+      html += `    <tr class="${lineClass}">
+      <td class="line-number">${lineNumber}</td>
+      <td class="line-content"><span class="line-marker">${marker}</span>${content}</td>
+    </tr>\n`;
+    } else {
+      html += `    <tr class="${lineClass}">
+      <td class="line-content"><span class="line-marker">${marker}</span>${content}</td>
+    </tr>\n`;
+    }
+  }
+
+  html += '  </table>\n';
+  html += '</div>\n';
+
+  return html;
+}
+
+/**
+ * Generate side-by-side diff view for a hunk
+ */
+function generateSideBySideHunk(hunk: DiffHunk, settings: PrintSettings): string {
+  let html = '<div class="diff-hunk">\n';
+
+  // Hunk header
+  html += `  <div class="hunk-header">@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@</div>\n`;
+
+  // Diff table
+  html += '  <table class="diff-side-by-side">\n';
+
+  // Process lines to align old and new versions
+  let i = 0;
+  while (i < hunk.lines.length) {
+    const line = hunk.lines[i];
+
+    if (line.type === 'context') {
+      // Context line appears in both columns
+      const oldLineNum = settings.showLineNumbers && line.oldLineNumber ? String(line.oldLineNumber) : '';
+      const newLineNum = settings.showLineNumbers && line.newLineNumber ? String(line.newLineNumber) : '';
+      const content = escapeHtml(line.content);
+
+      if (settings.showLineNumbers) {
+        html += `    <tr>
+      <td class="old-line-number">${oldLineNum}</td>
+      <td class="old-content context-line-old">${content}</td>
+      <td class="new-line-number">${newLineNum}</td>
+      <td class="new-content context-line-new">${content}</td>
+    </tr>\n`;
+      } else {
+        html += `    <tr>
+      <td class="old-content context-line-old">${content}</td>
+      <td class="new-content context-line-new">${content}</td>
+    </tr>\n`;
+      }
+
+      i++;
+    } else if (line.type === 'delete') {
+      // Look ahead for corresponding add lines
+      const deleteLines: DiffLine[] = [line];
+      let j = i + 1;
+
+      while (j < hunk.lines.length && hunk.lines[j].type === 'delete') {
+        deleteLines.push(hunk.lines[j]);
+        j++;
+      }
+
+      const addLines: DiffLine[] = [];
+      while (j < hunk.lines.length && hunk.lines[j].type === 'add') {
+        addLines.push(hunk.lines[j]);
+        j++;
+      }
+
+      // Align delete and add lines
+      const maxLines = Math.max(deleteLines.length, addLines.length);
+
+      for (let k = 0; k < maxLines; k++) {
+        const deleteLine = deleteLines[k];
+        const addLine = addLines[k];
+
+        let oldLineNum = '';
+        let oldContent = '';
+        let oldClass = '';
+
+        if (deleteLine) {
+          oldLineNum = settings.showLineNumbers && deleteLine.oldLineNumber ? String(deleteLine.oldLineNumber) : '';
+          oldContent = escapeHtml(deleteLine.content);
+          oldClass = 'delete-line-old';
+        } else {
+          oldClass = 'empty-line';
+        }
+
+        let newLineNum = '';
+        let newContent = '';
+        let newClass = '';
+
+        if (addLine) {
+          newLineNum = settings.showLineNumbers && addLine.newLineNumber ? String(addLine.newLineNumber) : '';
+          newContent = escapeHtml(addLine.content);
+          newClass = 'add-line-new';
+        } else {
+          newClass = 'empty-line';
+        }
+
+        if (settings.showLineNumbers) {
+          html += `    <tr>
+      <td class="old-line-number ${oldClass}">${oldLineNum}</td>
+      <td class="old-content ${oldClass}">${oldContent}</td>
+      <td class="new-line-number ${newClass}">${newLineNum}</td>
+      <td class="new-content ${newClass}">${newContent}</td>
+    </tr>\n`;
+        } else {
+          html += `    <tr>
+      <td class="old-content ${oldClass}">${oldContent}</td>
+      <td class="new-content ${newClass}">${newContent}</td>
+    </tr>\n`;
+        }
+      }
+
+      i = j;
+    } else if (line.type === 'add') {
+      // Add line without corresponding delete (pure addition)
+      const newLineNum = settings.showLineNumbers && line.newLineNumber ? String(line.newLineNumber) : '';
+      const content = escapeHtml(line.content);
+
+      if (settings.showLineNumbers) {
+        html += `    <tr>
+      <td class="old-line-number empty-line"></td>
+      <td class="old-content empty-line"></td>
+      <td class="new-line-number add-line-new">${newLineNum}</td>
+      <td class="new-content add-line-new">${content}</td>
+    </tr>\n`;
+      } else {
+        html += `    <tr>
+      <td class="old-content empty-line"></td>
+      <td class="new-content add-line-new">${content}</td>
+    </tr>\n`;
+      }
+
+      i++;
+    }
+  }
+
+  html += '  </table>\n';
+  html += '</div>\n';
+
+  return html;
+}
+
+/**
+ * Generate footer HTML
+ */
+function generateFooter(): string {
+  const now = new Date();
+  const dateStr = now.toLocaleDateString();
+  const timeStr = now.toLocaleTimeString();
+
+  return `
+    <div class="footer">
+      <p>Generated by VSPrint - ${dateStr} ${timeStr}</p>
+    </div>
+  `;
+}
+
+/**
+ * Generate complete diff HTML document
+ */
+export async function generateDiffHtml(
+  hunks: DiffHunk[],
+  fileName: string,
+  filePath: string,
+  diffType: string,
+  settings: PrintSettings
+): Promise<string> {
+  const styles = generateDiffStyles(settings);
+  const header = generateDiffHeader(fileName, filePath, diffType);
+  const footer = generateFooter();
+
+  // Determine diff mode from settings
+  const diffMode = settings.diff?.mode || 'sideBySide';
+
+  // Generate hunks based on mode
+  let hunksHtml = '';
+  for (const hunk of hunks) {
+    if (diffMode === 'unified') {
+      hunksHtml += generateUnifiedHunk(hunk, settings);
+    } else {
+      hunksHtml += generateSideBySideHunk(hunk, settings);
+    }
+  }
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(fileName)} - Git Diff</title>
+  ${styles}
+</head>
+<body>
+  ${header}
+  ${hunksHtml}
+  ${footer}
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
- Implement git diff printing using VS Code Git extension API
- Support unified and side-by-side diff display modes  
- Color-coded additions (green) and deletions (red)
- Line number support for both old and new versions
- QuickPick UI for selecting diff type (unstaged/staged/vs HEAD)

## Test plan
- [ ] Open file with unstaged changes, run "VSPrint: Print Git Diff"
- [ ] Verify additions are green, deletions are red
- [ ] Test side-by-side mode aligns old/new versions correctly
- [ ] Test unified mode shows traditional +/- format

Closes #31